### PR TITLE
Footer is now fixed at the bottom of the pages

### DIFF
--- a/app/assets/stylesheets/components/_footer.scss
+++ b/app/assets/stylesheets/components/_footer.scss
@@ -6,6 +6,10 @@
   height: 100px;
   padding: 0px 50px;
   color: rgba(0,0,0,0.3);
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  width: 100%;
 }
 .footer-links {
   display: flex;


### PR DESCRIPTION
Pour hiérarchiser les informations et pour améliorer le design, j'ai fixé le footer en bas des pages. Qu'il ne puisse plus flotter au milieu d'une page. 
Il y a peut être d'autres méthodes pour le faire, mais ca fixe deja bien un bug actuel de design :-) 

AVANT: 
https://user-images.githubusercontent.com/67366601/90682081-bdf86100-e264-11ea-885a-3e581bdc9596.png

APRES: 
https://user-images.githubusercontent.com/67366601/90682101-c51f6f00-e264-11ea-8f59-6b2b9e09f099.png

(ne pas tenir compte du design du form, puisque je ne merge pas mes features, je ne peux voir qu'une branche à la fois)
